### PR TITLE
Reintroduserer mulighet til å deploy-e alle eksisterende images

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy.yml
+++ b/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: 'Deploy-er til ${{ env.NAMESPACE }} i ${{ env.CLUSTER }}'
         uses: 'nais/deploy/actions/deploy@v1'
         env:
-          REF: ${{ env.VERSION }}
+          REF: ${{ env.SHA }}
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: ${{ env.CLUSTER }}
           RESOURCE: ./nais/nais.yaml


### PR DESCRIPTION
Reintroduserer muligheten til å deploy-e alle versjoner av en app, uavhangig av om det tilhørende et image for et master-brygg eller fra en branch.