### PR TITLE
Push til master vil nå deploye med én gang i stedet for å gå gjennom slack.

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-push-to-master.yml
+++ b/.github/workflows/__DISTRIBUTED_on-push-to-master.yml
@@ -34,14 +34,13 @@ jobs:
           git tag $TAG
           git push origin $TAG
 
-      - name: Sjekk om slack-integrering er mulig
-        run: echo "::set-env name=SLACK_URL_SPECIFIED::$([[ ! -z $WEBHOOK_URL ]] && echo 'true' || echo 'false')"
+      - name: 'Deploy-er til default i prod-sbs'
+        uses: 'nais/deploy/actions/deploy@v1'
         env:
-          WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-
-      - name: Vis deploy-knapper i slack
-        if: env.SLACK_URL_SPECIFIED == 'true'
-        uses: navikt/deploy-trigger-slack-integration@v1
-        with:
-          slack_channel: "#dittnav-deploy-actions"
-          webhook_url: ${{ secrets.WEBHOOK_URL }}
+          REF: ${{ github.sha }}
+          APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
+          CLUSTER: prod-sbs
+          RESOURCE: ./nais/nais.yaml
+          VARS: ./nais/prod-sbs/default.json
+          VAR: version=${{ env.IMAGE }}
+          PRINT_PAYLOAD: true


### PR DESCRIPTION
Integrasjon med slack er fortsatt mulig ved å bruke skriptet "request_slack_buttons.sh", men ikke lenger nødvendig.