### PR TITLE
Action for kjøring av ende-til-ende-testene i docker-compose-prosjektet ved oppretting av PR

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-pr.yml
+++ b/.github/workflows/__DISTRIBUTED_on-pr.yml
@@ -13,7 +13,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: navikt/dittnav-docker-compose
-          ref: gh-action
           path: dittnav-docker-compose
           token: ${{ secrets.DOCKER_PKG_TOKEN }}
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Endte opp med å måtte legge denne actionen her. Med en felles Docker-action i pb-common-gh-actions blir dette "docker-in-docker-in-docker", og det ble fryktelig trøblete for kommunikasjon mellom servicer i docker-compose ende-til-ende-testene.