### PR TITLE
La til caching av dependencies. Bruker nye versjoner av actions fra p…

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-push-to-master.yml
+++ b/.github/workflows/__DISTRIBUTED_on-push-to-master.yml
@@ -15,13 +15,28 @@ jobs:
       - name: Sjekk ut koden
         uses: actions/checkout@v2
 
-      - name: Kompiler
-        uses: navikt/pb-common-gh-actions/build@v1
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.13
+
+      - name: Finn cache-variabler
+        uses: navikt/pb-common-gh-actions/cache-prep@v2
+
+      - name: Sett opp cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}${{ env.CACHE_KEY_NAMESPACE }}${{ hashFiles(env.CACHE_KEY_HASHED_PATH) }}
+
+      - name: Bygg prosjekt og kjør tester
+        uses: navikt/pb-common-gh-actions/build@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bygg, tag og push Docker image
-        uses: navikt/pb-common-gh-actions/docker-publish@v1
+        uses: navikt/pb-common-gh-actions/docker-publish@v2
         with:
           TAG_LATEST: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/__DISTRIBUTED_on-push-to-other-branches.yml
+++ b/.github/workflows/__DISTRIBUTED_on-push-to-other-branches.yml
@@ -13,7 +13,22 @@ jobs:
       - name: Sjekk ut koden
         uses: actions/checkout@v2
 
-      - name: Kompiler
-        uses: navikt/pb-common-gh-actions/build@v1
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.13
+
+      - name: Finn cache-variabler
+        uses: navikt/pb-common-gh-actions/cache-prep@v2
+
+      - name: Sett opp cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}${{ env.CACHE_KEY_NAMESPACE }}${{ hashFiles(env.CACHE_KEY_HASHED_PATH) }}
+
+      - name: Bygg prosjekt og kjør tester
+        uses: navikt/pb-common-gh-actions/build@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy-new-image.yml
+++ b/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy-new-image.yml
@@ -25,8 +25,13 @@ jobs:
           git checkout $GIT_REF
           echo "::set-env name=CURRENT_REF::$(git log -1 --pretty='%H')"
 
-      - name: Kompiler
-        uses: navikt/pb-common-gh-actions/build@v1
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.13
+
+      - name: Bygg prosjekt
+        uses: navikt/pb-common-gh-actions/build@v2
         with:
           SKIP_TESTS: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
+++ b/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
@@ -22,8 +22,23 @@ jobs:
           git checkout $COMMIT_BRANCH
           echo "::set-env name=CURRENT_REF::$(git log -1 --pretty='%H')"
 
-      - name: Kompiler
-        uses: navikt/pb-common-gh-actions/build@v1
+      - name: Setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.13
+
+      - name: Finn cache-variabler
+        uses: navikt/pb-common-gh-actions/cache-prep@v2
+
+      - name: Sett opp cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ${{ env.CACHE_PATHS }}
+          key: ${{ runner.os }}${{ env.CACHE_KEY_NAMESPACE }}${{ hashFiles(env.CACHE_KEY_HASHED_PATH) }}
+
+      - name: Bygg prosjekt
+        uses: navikt/pb-common-gh-actions/build@v2
         with:
           SKIP_TESTS: "true"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,7 +46,6 @@ jobs:
       - name: Bygg, tag og push Docker image
         uses: navikt/pb-common-gh-actions/docker-publish@v1
         with:
-          TAG_LATEST: "false"
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vis deploy-knapper i slack


### PR DESCRIPTION
De nye versjonene av actions bruker composite actions i stedet for docker, som kutter ned på tid brukt til oppsett. Caching av dependencies er satt opp for node, maven og gradle prosjekt.