### PR TITLE
Kjører ikke job for ende-til-ende-tester i repoer som ikke er med i docker-compose-oppsettet

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-pr.yml
+++ b/.github/workflows/__DISTRIBUTED_on-pr.yml
@@ -7,7 +7,7 @@ jobs:
   should-run-end-to-end-tests:
     if: github.repository != 'navikt/dittnav' && github.repository != 'navikt/dittnav-eventer-modia'
       && github.repository != 'navikt/dittnav-kafka-backup-reader' && github.repository != 'navikt/dittnav-nightly-usage-statistics-reporter'
-        && github.repository != 'navikt/innloggingsstatus'
+        && github.repository != 'navikt/innloggingsstatus' && github.repository != 'navikt/pb-workflow-authority'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Dette er en quickfix, og vi kan løse dette mer elegant senere.