### PR TITLE
Dropper kravet om at `dittnav-periodic-metrics-reporter` må kjøre e2e…

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-pr.yml
+++ b/.github/workflows/__DISTRIBUTED_on-pr.yml
@@ -8,6 +8,7 @@ jobs:
     if: github.repository != 'navikt/dittnav' && github.repository != 'navikt/dittnav-eventer-modia'
       && github.repository != 'navikt/dittnav-kafka-backup-reader' && github.repository != 'navikt/dittnav-nightly-usage-statistics-reporter'
         && github.repository != 'navikt/innloggingsstatus' && github.repository != 'navikt/pb-workflow-authority'
+        && github.repository != 'navikt/dittnav-periodic-metrics-reporter'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
…-testene ved oppretting av PR.

Siden `dittnav-periodic-metrics-reporter` foreløpig ikke er dratt inn som en del av e2e-testene.