### PR TITLE
Oppdaterer pb-common-gh-actions versjon

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy-new-image.yml
+++ b/.github/workflows/__DISTRIBUTED_on-repo-dispatch-deploy-new-image.yml
@@ -37,7 +37,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bygg, tag og push Docker image
-        uses: navikt/pb-common-gh-actions/docker-publish@v1
+        uses: navikt/pb-common-gh-actions/docker-publish@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
+++ b/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Bygg, tag og push Docker image
-        uses: navikt/pb-common-gh-actions/docker-publish@v1
+        uses: navikt/pb-common-gh-actions/docker-publish@v2
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
Oppdaterer til siste versjon av pb-common-gh-actions som ikke bruker `::set-env` 