### PR TITLE
Skal ikke kjøre e2e-tester for pb-oidc-provider-gui

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-pr.yml
+++ b/.github/workflows/__DISTRIBUTED_on-pr.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.repository != 'navikt/dittnav' && github.repository != 'navikt/dittnav-eventer-modia'
       && github.repository != 'navikt/dittnav-kafka-backup-reader' && github.repository != 'navikt/dittnav-nightly-usage-statistics-reporter'
         && github.repository != 'navikt/innloggingsstatus' && github.repository != 'navikt/pb-workflow-authority'
-        && github.repository != 'navikt/dittnav-periodic-metrics-reporter'
+        && github.repository != 'navikt/dittnav-periodic-metrics-reporter' && github.repository != 'navikt/pb-oidc-provider-gui'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Ekskluderer denne, siden det er en frontend-app (som vi ikke støtter i e2e-testene).