### PR TITLE
Deploy til pod via fil "personbruker.json" i stedet for "default.json".

### DIFF
--- a/.github/workflows/__DISTRIBUTED_on-push-to-main.yml
+++ b/.github/workflows/__DISTRIBUTED_on-push-to-main.yml
@@ -51,7 +51,7 @@ jobs:
           git push origin $TAG
 
       - name: Sjekk om prodsetting er mulig
-        run: echo "PROD_SBS_VARS_TEMPLATE_DEFINED=$([[ -f ./nais/prod-sbs/default.json ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
+        run: echo "PROD_SBS_VARS_TEMPLATE_DEFINED=$([[ -f ./nais/prod-sbs/personbruker.json ]] && echo 'true' || echo 'false')" >> $GITHUB_ENV
 
       - name: 'Deploy-er til default i prod-sbs'
         if: env.PROD_SBS_VARS_TEMPLATE_DEFINED == 'true'
@@ -61,7 +61,7 @@ jobs:
           APIKEY: ${{ secrets.NAIS_DEPLOY_APIKEY }}
           CLUSTER: prod-sbs
           RESOURCE: ./nais/nais.yaml
-          VARS: ./nais/prod-sbs/default.json
+          VARS: ./nais/prod-sbs/personbruker.json
           VAR: version=${{ env.IMAGE }}
           PRINT_PAYLOAD: true
 

--- a/config/default_include_apps.conf
+++ b/config/default_include_apps.conf
@@ -3,7 +3,6 @@ dittnav-event-handler
 dittnav-event-test-producer
 dittnav
 dittnav-api
-dittnav-eventer-modia
 pb-nav-mocked
 pb-oidc-provider-gui
 dittnav-kafka-backup-reader


### PR DESCRIPTION
Bytter til å deploye til prod med vars fil "personbruker.json". Det skal nå være mulig å slette "default.json" for de berørte appene.

Dittnav-eventer-modia er fjernet fra listen over styrte apper. Dette er gjort fordi den allerede ikke var kompatibel med eksisterende workflows. Ettersom dette er den eneste appen vi har i fss, bør denne håndteres manuelt.