### PR TITLE
Bytt til v2 av slack-deploy-knapper.

### DIFF
--- a/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
+++ b/.github/workflows/__DISTRIBUTED_show_slack_buttons_dispatch.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Vis deploy-knapper i slack
-        uses: navikt/deploy-trigger-slack-integration@v1
+        uses: navikt/deploy-trigger-slack-integration@v2
         with:
           slack_channel: "#dittnav-deploy-actions"
           webhook_url: ${{ secrets.WEBHOOK_URL }}


### PR DESCRIPTION
Disse knappene tillater deploy til andre miljø enn sbs, og viser dette tydeligere.