### PR TITLE
Sørger for at Snyk-sjekkene kjører igjen

### DIFF
--- a/.github/workflows/__DISTRIBUTED_snyk.yaml
+++ b/.github/workflows/__DISTRIBUTED_snyk.yaml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Run Snyk for gradle to check for vulnerabilities
         if: env.IS_GRADLE_PROJECT == 'true'
-        uses: snyk/actions/gradle@master
+        uses: snyk/actions/gradle-jdk14@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:


### PR DESCRIPTION
Action-en som vi bruker for å kjøre Snyk-sjekker har nå blitt oppdatert til å bruke JDK-versjoner som våre Gradle-versjoner ikke støtter. Vi er typisk på Gradle versjon 6, som kun støtter JDK-ene på versjoner <16. Tvinger her Snyk-sjekkene til å bruke JDK-versjon 14, i stede for versjon 17 som nå er det som automatisk blir dratt inn på GHA.