### PR TITLE
Fjerner dittnav-tidslinje-api midlertidig fra workflow-distribuering

### DIFF
--- a/config/default_include_apps.conf
+++ b/config/default_include_apps.conf
@@ -7,7 +7,6 @@ pb-nav-mocked
 pb-oidc-provider-gui
 dittnav-nightly-usage-statistics-reporter
 dittnav-periodic-metrics-reporter
-dittnav-tidslinje-api
 dittnav-varselbestiller
 utbetalingsoversikt
 mine-saker


### PR DESCRIPTION
Fjerner deploy-steget fra appens workflows, siden den midlertidig ikke skal være deployet til noe miljø. Vil derfor hindre at appen får nye workflows som legger automatisk deploy utilsiktet tilbake igjen. 