### PR TITLE
Legger til tms-event-api i listen for applikasjoner det skal distribu…

### DIFF
--- a/config/default_include_apps.conf
+++ b/config/default_include_apps.conf
@@ -26,3 +26,4 @@ tms-min-side-varslinger
 internal-periodic-metrics-reporter
 tms-ettersendelse-fallback-vitejs
 saksoversikt
+tms-event-api


### PR DESCRIPTION
…eres workflows til.

Dette er proxy-en som Salesforce skal benytte for å hente eventer fra oss fra event-handler.